### PR TITLE
Fixed: Cart overlapped with login screen

### DIFF
--- a/client/src/components/Cart/Cart.jsx
+++ b/client/src/components/Cart/Cart.jsx
@@ -132,7 +132,7 @@ export default function Cart() {
                 ) : (
                   <p>
                     <strong>
-                      <Link to="/login" className={style.resaltar}>
+                      <Link to="/login" className={style.resaltar} onClick={() => setActiveCart()}>
                         Logueate
                       </Link>
                     </strong>{" "}


### PR DESCRIPTION
Se arreglo el bug en el cual al ir al login desde el carrito, este se quedaba superpuesto con la pantalla de login, sin posibilidad de cerrarlo